### PR TITLE
Climbed boulder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ build
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+boulder.json

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,7 +7,7 @@ function App() {
  
   const bouldersList = [
     {
-      number: 1,
+      id: "1",
       name: 'Black Widow and the people',
       sector: 'Monkey Island',
       level: '5',
@@ -23,7 +23,7 @@ function App() {
       climbers: [],
     },
     {
-      number: 2,
+      id: "2",
       name: 'Orang Utan',
       sector: 'Monkey Island',
       level: '3',
@@ -39,7 +39,7 @@ function App() {
       climbers: [],
     },
     {
-      number: 3,
+      id: "3",
       name: 'Tarzan',
       sector: 'Monkey Island',
       level: '3',

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,7 @@
-import BoulderCard from './components/BoulderCard';
-import styled from 'styled-components';
+import { Routes, Route } from 'react-router-dom';
+import Find from './pages/Find';
+import Add from './pages/Add';
+
 
 function App() {
  
@@ -56,34 +58,24 @@ function App() {
 
 
   return (
-    <div className='App'>
-     <BoulderList role='list'>
-      {bouldersList.map(boulder => (
-        <BoulderCard 
-        key={boulder.number}
-        id={boulder.number}
-        name={boulder.name}
-        sector={boulder.sector}
-        level={boulder.level}
-        hold_color={boulder.hold_color}
-        img_start={boulder.img_start}
-        likes={boulder.number_of_likes}
-        setter={boulder.setter}
-        tags={boulder.tags}
-        weighting={boulder.weighting}
-        detailedMode={false}
+    <>
+   
+      <Routes>
+        <Route path="/" element={<Find bouldersList={bouldersList} />} />
+        <Route
+          path="/add/:id"
+          element={
+            <Add
+              bouldersList={bouldersList}
+            />
+          }
         />
-      ))}
-     </BoulderList>
-    </div>
+      </Routes>
+    
+    </>
   );
+
 }
 
 export default App;
 
-const BoulderList = styled.ul`
-  width: 95%;
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-`

--- a/client/src/components/AddClimbedBoulderForm.jsx
+++ b/client/src/components/AddClimbedBoulderForm.jsx
@@ -16,6 +16,7 @@ const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
         saveClimbedBoulder(date, projected, attempts, result, liked, levelFeedback);
       }}
     >
+      <p>Save your achievement!</p>
       <label htmlFor="date">Climb date:</label>
       <input
         type="date"
@@ -37,7 +38,7 @@ const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
           placeholder=""
           value={projected}
           onChange={event => {
-            setProjected(event.target.value);
+            setProjected(event.target.checked);
           }}
         ></input>
       </div>
@@ -56,7 +57,8 @@ const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
       </div>
       <fieldset>
         <legend>Your result:</legend>
-        <div>
+        <RadioButtonWrapper>
+           <div>
           <input
             type="radio"
             id="zone"
@@ -97,7 +99,6 @@ const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
           />
           <label htmlFor="flash">Flash</label>
         </div>
-        <div>
           <button
             onClick={event => {
               event.preventDefault();
@@ -106,9 +107,9 @@ const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
           >
             x
           </button>
-        </div>
+        </RadioButtonWrapper>
       </fieldset>
-
+      <p>Give us your feedback!</p>
       <div>
         <label htmlFor="liked">Like: </label>
         <input
@@ -118,14 +119,15 @@ const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
           placeholder=""
           value={liked}
           onChange={event => {
-            setLiked(event.target.value);
+            setLiked(event.target.checked);
           }}
         ></input>
       </div>
 
       <fieldset>
         <legend>Level Feedback</legend>
-        <div>
+        <RadioButtonWrapper>
+          <div>
           <input
             type="radio"
             id="tooeasy"
@@ -174,6 +176,8 @@ const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
         >
           x
         </button>
+        </RadioButtonWrapper>
+        
       </fieldset>
       <button>Save</button>
     </BoulderForm>
@@ -187,4 +191,10 @@ const BoulderForm = styled.form`
   max-width: 90%;
   display: flex;
   flex-direction: column;
+  gap: 0.5rem;
 `;
+
+const RadioButtonWrapper = styled.div`
+display: flex;
+justify-content: space-between;
+`

--- a/client/src/components/AddClimbedBoulderForm.jsx
+++ b/client/src/components/AddClimbedBoulderForm.jsx
@@ -1,21 +1,21 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 
-const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
+const AddClimbedBoulderForm = ({ saveClimbedBoulder }) => {
   const [projected, setProjected] = useState(false);
-  const [attempts, setAttempts] = useState("");
+  const [attempts, setAttempts] = useState('');
   const [result, setResult] = useState();
   const [liked, setLiked] = useState(false);
   const [levelFeedback, setLevelFeedback] = useState();
-  
 
   return (
     <BoulderForm
-      onSubmit={(event) => {event.preventDefault();
+      onSubmit={event => {
+        event.preventDefault();
         saveClimbedBoulder(projected, attempts, result, liked, levelFeedback);
       }}
     >
-      <p>Save your achievement!</p>
+      <h3>Save your achievement!</h3>
       <div>
         <label htmlFor="projected">Projected: </label>
         <input
@@ -43,47 +43,45 @@ const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
       <fieldset>
         <legend>Your result:</legend>
         <RadioButtonWrapper>
-           <div>
-          <input
-            type="radio"
-            id="zone"
-            name="result"
-            value="zone"
-            checked={result === 'zone'}
-            onChange={event => {
-              setResult(event.target.value);
-            }}
-          />
-          <label htmlFor="zone">Zone</label>
-        </div>
-
-        <div>
-          <input
-            type="radio"
-            id="top"
-            name="result"
-            value="top"
-            checked={result === 'top'}
-            onChange={event => {
-              setResult(event.target.value);
-            }}
-          />
-          <label htmlFor="top">Top</label>
-        </div>
-
-        <div>
-          <input
-            type="radio"
-            id="flash"
-            name="result"
-            value="flash"
-            checked={result === 'flash'}
-            onChange={event => {
-              setResult(event.target.value);
-            }}
-          />
-          <label htmlFor="flash">Flash</label>
-        </div>
+          <div>
+            <input
+              type="radio"
+              id="zone"
+              name="result"
+              value="zone"
+              checked={result === 'zone'}
+              onChange={event => {
+                setResult(event.target.value);
+              }}
+            />
+            <label htmlFor="zone">Zone</label>
+          </div>
+          <div>
+            <input
+              type="radio"
+              id="top"
+              name="result"
+              value="top"
+              checked={result === 'top'}
+              onChange={event => {
+                setResult(event.target.value);
+              }}
+            />
+            <label htmlFor="top">Top</label>
+          </div>
+          <div>
+            <input
+              type="radio"
+              id="flash"
+              name="result"
+              value="flash"
+              checked={result === 'flash'}
+              onChange={event => {
+                setResult(event.target.value);
+              }}
+            />
+            <label htmlFor="flash">Flash</label>
+          </div>
           <button
             onClick={event => {
               event.preventDefault();
@@ -94,7 +92,7 @@ const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
           </button>
         </RadioButtonWrapper>
       </fieldset>
-      <p>Give us your feedback!</p>
+      <h3>Give us your feedback!</h3>
       <div>
         <label htmlFor="liked">Like: </label>
         <input
@@ -107,61 +105,57 @@ const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
           }}
         ></input>
       </div>
-
       <fieldset>
         <legend>Level Feedback</legend>
         <RadioButtonWrapper>
           <div>
-          <input
-            type="radio"
-            id="tooeasy"
-            name="levelFeedback"
-            value="tooeasy"
-            checked={levelFeedback === 'tooeasy'}
-            onChange={event => {
-              setLevelFeedback(event.target.value);
+            <input
+              type="radio"
+              id="tooEasy"
+              name="levelFeedback"
+              value="tooEasy"
+              checked={levelFeedback === 'tooEasy'}
+              onChange={event => {
+                setLevelFeedback(event.target.value);
+              }}
+            />
+            <label htmlFor="tooEasy">Too easy</label>
+          </div>
+          <div>
+            <input
+              type="radio"
+              id="justRight"
+              name="levelFeedback"
+              value="justRight"
+              checked={levelFeedback === 'justRight'}
+              onChange={event => {
+                setLevelFeedback(event.target.value);
+              }}
+            />
+            <label htmlFor="justRight">Just right</label>
+          </div>
+          <div>
+            <input
+              type="radio"
+              id="tooHard"
+              name="levelFeedback"
+              value="tooHard"
+              checked={levelFeedback === 'tooHard'}
+              onChange={event => {
+                setLevelFeedback(event.target.value);
+              }}
+            />
+            <label htmlFor="tooHard">Too hard</label>
+          </div>
+          <button
+            onClick={event => {
+              event.preventDefault();
+              setLevelFeedback('');
             }}
-          />
-          <label htmlFor="tooeasy">Too easy</label>
-        </div>
-
-        <div>
-          <input
-            type="radio"
-            id="justright"
-            name="levelFeedback"
-            value="justright"
-            checked={levelFeedback === 'justright'}
-            onChange={event => {
-              setLevelFeedback(event.target.value);
-            }}
-          />
-          <label htmlFor="justright">Just right</label>
-        </div>
-
-        <div>
-          <input
-            type="radio"
-            id="toohard"
-            name="levelFeedback"
-            value="toohard"
-            checked={levelFeedback === 'toohard'}
-            onChange={event => {
-              setLevelFeedback(event.target.value);
-            }}
-          />
-          <label htmlFor="toohard">Too hard</label>
-        </div>
-        <button
-          onClick={event => {
-            event.preventDefault();
-            setLevelFeedback('');
-          }}
-        >
-          x
-        </button>
+          >
+            x
+          </button>
         </RadioButtonWrapper>
-        
       </fieldset>
       <button>Save</button>
     </BoulderForm>
@@ -179,6 +173,6 @@ const BoulderForm = styled.form`
 `;
 
 const RadioButtonWrapper = styled.div`
-display: flex;
-justify-content: space-between;
-`
+  display: flex;
+  justify-content: space-between;
+`;

--- a/client/src/components/AddClimbedBoulderForm.jsx
+++ b/client/src/components/AddClimbedBoulderForm.jsx
@@ -1,0 +1,156 @@
+import { useState } from 'react';
+import styled from 'styled-components'
+
+const AddClimbedBoulderForm = () => {
+ 
+  const [date, setDate] = useState(new Date());
+  const [projected, setProjected] = useState(false);
+  const [attempts, setAttempts] = useState();
+  const [result, setResult] = useState();
+  const [liked, setLiked] = useState(false);
+  const [levelFeedback, setLevelFeedback] = useState();
+
+  return (
+    <BoulderForm onSubmit={event => {}}>
+      <label htmlFor="date">Title:</label>
+      <input
+        type="date"
+        id="date"
+        name="date"
+        placeholder=""
+        value={date}
+        onChange={event => {
+          setDate(event.target.value);
+        }}
+      ></input>
+      <label htmlFor="projected">Projected:</label>
+      <input
+        type="checkbox"
+        id="projected"
+        name="projected"
+        placeholder=""
+        value={projected}
+        onChange={event => {
+          setProjected(event.target.value);
+        }}
+      ></input>
+      <label htmlFor="attempts">Attempts:</label>
+      <input
+        type="number"
+        id="attempts"
+        name="attempts"
+        placeholder="0"
+        value={attempts}
+        onChange={event => {
+          setAttempts(event.target.value);
+        }}
+      ></input>
+      <div>
+        <input
+          type="radio"
+          id="zone"
+          name="result"
+          value="zone"
+          checked={result === 'zone'}
+          onChange={event => {
+            setResult(event.target.value);
+          }}
+        />
+        <label for="zone">Zone</label>
+      </div>
+
+      <div>
+        <input
+          type="radio"
+          id="top"
+          name="result"
+          value="top"
+          checked={result === 'top'}
+          onChange={event => {
+            setResult(event.target.value);
+          }}
+        />
+        <label for="top">Top</label>
+      </div>
+
+      <div>
+        <input
+          type="radio"
+          id="flash"
+          name="result"
+          value="flash"
+          checked={result === 'flash'}
+          onChange={event => {
+            setResult(event.target.value);
+          }}
+        />
+        <label for="flash">Flash</label>
+      </div>
+
+      <label htmlFor="liked">Like:</label>
+      <input
+        type="checkbox"
+        id="liked"
+        name="liked"
+        placeholder=""
+        value={liked}
+        onChange={event => {
+          setLiked(event.target.value);
+        }}
+      ></input>
+      <div>
+        <input
+          type="radio"
+          id="tooeasy"
+          name="levelFeedback"
+          value="tooeasy"
+          checked={levelFeedback === 'tooeasy'}
+          onChange={event => {
+            setLevelFeedback(event.target.value);
+          }}
+        />
+        <label for="tooeasy">Too easy</label>
+      </div>
+
+      <div>
+        <input
+          type="radio"
+          id="justright"
+          name="levelFeedback"
+          value="justright"
+          checked={levelFeedback === 'justright'}
+          onChange={event => {
+            setLevelFeedback(event.target.value);
+          }}
+        />
+        <label for="justright">Just right</label>
+      </div>
+
+      <div>
+        <input
+          type="radio"
+          id="toohard"
+          name="levelFeedback"
+          value="toohard"
+          checked={levelFeedback === 'toohard'}
+          onChange={event => {
+            setLevelFeedback(event.target.value);
+          }}
+        />
+        <label for="toohard">Too hard</label>
+      </div>
+      <button>Save</button>
+    </BoulderForm>
+  );
+};
+
+export default AddClimbedBoulderForm;
+
+
+const BoulderForm = styled.form`
+  max-width: 90%;
+  display: flex;
+  flex-direction: column;
+`;
+
+

--- a/client/src/components/AddClimbedBoulderForm.jsx
+++ b/client/src/components/AddClimbedBoulderForm.jsx
@@ -1,144 +1,180 @@
 import { useState } from 'react';
-import styled from 'styled-components'
+import styled from 'styled-components';
 
-const AddClimbedBoulderForm = () => {
- 
+const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
   const [date, setDate] = useState(new Date());
   const [projected, setProjected] = useState(false);
-  const [attempts, setAttempts] = useState();
+  const [attempts, setAttempts] = useState(0);
   const [result, setResult] = useState();
   const [liked, setLiked] = useState(false);
   const [levelFeedback, setLevelFeedback] = useState();
+  
 
   return (
-    <BoulderForm onSubmit={event => {}}>
-      <label htmlFor="date">Title:</label>
+    <BoulderForm
+      onSubmit={(event) => {event.preventDefault();
+        saveClimbedBoulder(date, projected, attempts, result, liked, levelFeedback);
+      }}
+    >
+      <label htmlFor="date">Climb date:</label>
       <input
         type="date"
         id="date"
         name="date"
-        placeholder=""
+        // defaultValue={date}
+        placeholder={date}
         value={date}
         onChange={event => {
           setDate(event.target.value);
         }}
       ></input>
-      <label htmlFor="projected">Projected:</label>
-      <input
-        type="checkbox"
-        id="projected"
-        name="projected"
-        placeholder=""
-        value={projected}
-        onChange={event => {
-          setProjected(event.target.value);
-        }}
-      ></input>
-      <label htmlFor="attempts">Attempts:</label>
-      <input
-        type="number"
-        id="attempts"
-        name="attempts"
-        placeholder="0"
-        value={attempts}
-        onChange={event => {
-          setAttempts(event.target.value);
-        }}
-      ></input>
       <div>
+        <label htmlFor="projected">Projected: </label>
         <input
-          type="radio"
-          id="zone"
-          name="result"
-          value="zone"
-          checked={result === 'zone'}
+          type="checkbox"
+          id="projected"
+          name="projected"
+          placeholder=""
+          value={projected}
           onChange={event => {
-            setResult(event.target.value);
+            setProjected(event.target.value);
           }}
-        />
-        <label for="zone">Zone</label>
+        ></input>
       </div>
+      <div>
+        <label htmlFor="attempts">Attempts: </label>
+        <input
+          type="number"
+          id="attempts"
+          name="attempts"
+          placeholder="0"
+          value={attempts}
+          onChange={event => {
+            setAttempts(event.target.value);
+          }}
+        ></input>
+      </div>
+      <fieldset>
+        <legend>Your result:</legend>
+        <div>
+          <input
+            type="radio"
+            id="zone"
+            name="result"
+            value="zone"
+            checked={result === 'zone'}
+            onChange={event => {
+              setResult(event.target.value);
+            }}
+          />
+          <label htmlFor="zone">Zone</label>
+        </div>
+
+        <div>
+          <input
+            type="radio"
+            id="top"
+            name="result"
+            value="top"
+            checked={result === 'top'}
+            onChange={event => {
+              setResult(event.target.value);
+            }}
+          />
+          <label htmlFor="top">Top</label>
+        </div>
+
+        <div>
+          <input
+            type="radio"
+            id="flash"
+            name="result"
+            value="flash"
+            checked={result === 'flash'}
+            onChange={event => {
+              setResult(event.target.value);
+            }}
+          />
+          <label htmlFor="flash">Flash</label>
+        </div>
+        <div>
+          <button
+            onClick={event => {
+              event.preventDefault();
+              setResult('');
+            }}
+          >
+            x
+          </button>
+        </div>
+      </fieldset>
 
       <div>
+        <label htmlFor="liked">Like: </label>
         <input
-          type="radio"
-          id="top"
-          name="result"
-          value="top"
-          checked={result === 'top'}
+          type="checkbox"
+          id="liked"
+          name="liked"
+          placeholder=""
+          value={liked}
           onChange={event => {
-            setResult(event.target.value);
+            setLiked(event.target.value);
           }}
-        />
-        <label for="top">Top</label>
+        ></input>
       </div>
 
-      <div>
-        <input
-          type="radio"
-          id="flash"
-          name="result"
-          value="flash"
-          checked={result === 'flash'}
-          onChange={event => {
-            setResult(event.target.value);
-          }}
-        />
-        <label for="flash">Flash</label>
-      </div>
+      <fieldset>
+        <legend>Level Feedback</legend>
+        <div>
+          <input
+            type="radio"
+            id="tooeasy"
+            name="levelFeedback"
+            value="tooeasy"
+            checked={levelFeedback === 'tooeasy'}
+            onChange={event => {
+              setLevelFeedback(event.target.value);
+            }}
+          />
+          <label htmlFor="tooeasy">Too easy</label>
+        </div>
 
-      <label htmlFor="liked">Like:</label>
-      <input
-        type="checkbox"
-        id="liked"
-        name="liked"
-        placeholder=""
-        value={liked}
-        onChange={event => {
-          setLiked(event.target.value);
-        }}
-      ></input>
-      <div>
-        <input
-          type="radio"
-          id="tooeasy"
-          name="levelFeedback"
-          value="tooeasy"
-          checked={levelFeedback === 'tooeasy'}
-          onChange={event => {
-            setLevelFeedback(event.target.value);
-          }}
-        />
-        <label for="tooeasy">Too easy</label>
-      </div>
+        <div>
+          <input
+            type="radio"
+            id="justright"
+            name="levelFeedback"
+            value="justright"
+            checked={levelFeedback === 'justright'}
+            onChange={event => {
+              setLevelFeedback(event.target.value);
+            }}
+          />
+          <label htmlFor="justright">Just right</label>
+        </div>
 
-      <div>
-        <input
-          type="radio"
-          id="justright"
-          name="levelFeedback"
-          value="justright"
-          checked={levelFeedback === 'justright'}
-          onChange={event => {
-            setLevelFeedback(event.target.value);
+        <div>
+          <input
+            type="radio"
+            id="toohard"
+            name="levelFeedback"
+            value="toohard"
+            checked={levelFeedback === 'toohard'}
+            onChange={event => {
+              setLevelFeedback(event.target.value);
+            }}
+          />
+          <label htmlFor="toohard">Too hard</label>
+        </div>
+        <button
+          onClick={event => {
+            event.preventDefault();
+            setLevelFeedback('');
           }}
-        />
-        <label for="justright">Just right</label>
-      </div>
-
-      <div>
-        <input
-          type="radio"
-          id="toohard"
-          name="levelFeedback"
-          value="toohard"
-          checked={levelFeedback === 'toohard'}
-          onChange={event => {
-            setLevelFeedback(event.target.value);
-          }}
-        />
-        <label for="toohard">Too hard</label>
-      </div>
+        >
+          x
+        </button>
+      </fieldset>
       <button>Save</button>
     </BoulderForm>
   );
@@ -146,11 +182,9 @@ const AddClimbedBoulderForm = () => {
 
 export default AddClimbedBoulderForm;
 
-
 const BoulderForm = styled.form`
+  margin: 0.5rem auto;
   max-width: 90%;
   display: flex;
   flex-direction: column;
 `;
-
-

--- a/client/src/components/AddClimbedBoulderForm.jsx
+++ b/client/src/components/AddClimbedBoulderForm.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
   const [projected, setProjected] = useState(false);
-  const [attempts, setAttempts] = useState(0);
+  const [attempts, setAttempts] = useState("");
   const [result, setResult] = useState();
   const [liked, setLiked] = useState(false);
   const [levelFeedback, setLevelFeedback] = useState();
@@ -22,7 +22,6 @@ const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
           type="checkbox"
           id="projected"
           name="projected"
-          placeholder=""
           value={projected}
           onChange={event => {
             setProjected(event.target.checked);
@@ -35,7 +34,6 @@ const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
           type="number"
           id="attempts"
           name="attempts"
-          placeholder="0"
           value={attempts}
           onChange={event => {
             setAttempts(event.target.value);
@@ -103,7 +101,6 @@ const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
           type="checkbox"
           id="liked"
           name="liked"
-          placeholder=""
           value={liked}
           onChange={event => {
             setLiked(event.target.checked);

--- a/client/src/components/AddClimbedBoulderForm.jsx
+++ b/client/src/components/AddClimbedBoulderForm.jsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
-  const [date, setDate] = useState(new Date());
   const [projected, setProjected] = useState(false);
   const [attempts, setAttempts] = useState(0);
   const [result, setResult] = useState();
@@ -13,22 +12,10 @@ const AddClimbedBoulderForm = ({saveClimbedBoulder}) => {
   return (
     <BoulderForm
       onSubmit={(event) => {event.preventDefault();
-        saveClimbedBoulder(date, projected, attempts, result, liked, levelFeedback);
+        saveClimbedBoulder(projected, attempts, result, liked, levelFeedback);
       }}
     >
       <p>Save your achievement!</p>
-      <label htmlFor="date">Climb date:</label>
-      <input
-        type="date"
-        id="date"
-        name="date"
-        // defaultValue={date}
-        placeholder={date}
-        value={date}
-        onChange={event => {
-          setDate(event.target.value);
-        }}
-      ></input>
       <div>
         <label htmlFor="projected">Projected: </label>
         <input

--- a/client/src/components/AddClimbedBoulderForm.spec.jsx
+++ b/client/src/components/AddClimbedBoulderForm.spec.jsx
@@ -1,0 +1,44 @@
+import AddClimbedBoulderForm from './AddClimbedBoulderForm';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+
+describe('AddClimbedBoulderForm', () => {
+    it('renders 2 checkbox, 6 radio buttons, 1 number input field, 2 reset buttons and a submit button', () => {
+        render (<AddClimbedBoulderForm/>);
+
+        const checkboxesAll = screen.getAllByRole('checkbox');
+        const radioButtonsAll = screen.getAllByRole('radio');
+        const nameOfNumberInput = screen.getByLabelText(/Attempts/i);
+        const resetButtons = screen.getAllByRole('button', {name: /x/i});
+        const submitButton = screen.getByRole('button', {name: /Save/i});
+
+        expect(checkboxesAll).toHaveLength(2);
+        expect(radioButtonsAll).toHaveLength(6);
+        expect(nameOfNumberInput).toBeInTheDocument();
+        expect(resetButtons).toHaveLength(2);
+        expect(submitButton).toBeInTheDocument();
+
+    })
+
+    it('submits form data if none of the input fields is filled out', () =>{
+        const handleAdd = jest.fn(); 
+        render (<AddClimbedBoulderForm saveClimbedBoulder={handleAdd}/>);
+        const submitButton = screen.getByRole('button', {name: /Save/i});
+
+        userEvent.click(submitButton);
+
+        expect(handleAdd).toHaveBeenCalledTimes(1);
+    })
+    
+    it('submits form data if one of the input fields is filled out', () =>{
+        const handleAdd = jest.fn(); 
+        render (<AddClimbedBoulderForm saveClimbedBoulder={handleAdd}/>);
+        const submitButton = screen.getByRole('button', {name: /Save/i});
+        const nameOfNumberInput = screen.getByLabelText(/Attempts/i);
+ 
+        userEvent.type(nameOfNumberInput, '2')
+        userEvent.click(submitButton);
+
+        expect(handleAdd).toHaveBeenCalledTimes(1);
+    })
+})

--- a/client/src/components/AddClimbedBoulderForm.spec.jsx
+++ b/client/src/components/AddClimbedBoulderForm.spec.jsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 
 describe('AddClimbedBoulderForm', () => {
-    it('renders 2 checkbox, 6 radio buttons, 1 number input field, 2 reset buttons and a submit button', () => {
+    it('renders 2 checkboxes, 6 radio buttons, 1 number input field, 2 reset buttons and a submit button', () => {
         render (<AddClimbedBoulderForm/>);
 
         const checkboxesAll = screen.getAllByRole('checkbox');
@@ -17,7 +17,6 @@ describe('AddClimbedBoulderForm', () => {
         expect(nameOfNumberInput).toBeInTheDocument();
         expect(resetButtons).toHaveLength(2);
         expect(submitButton).toBeInTheDocument();
-
     })
 
     it('submits form data if none of the input fields is filled out', () =>{
@@ -25,18 +24,6 @@ describe('AddClimbedBoulderForm', () => {
         render (<AddClimbedBoulderForm saveClimbedBoulder={handleAdd}/>);
         const submitButton = screen.getByRole('button', {name: /Save/i});
 
-        userEvent.click(submitButton);
-
-        expect(handleAdd).toHaveBeenCalledTimes(1);
-    })
-    
-    it('submits form data if one of the input fields is filled out', () =>{
-        const handleAdd = jest.fn(); 
-        render (<AddClimbedBoulderForm saveClimbedBoulder={handleAdd}/>);
-        const submitButton = screen.getByRole('button', {name: /Save/i});
-        const nameOfNumberInput = screen.getByLabelText(/Attempts/i);
- 
-        userEvent.type(nameOfNumberInput, '2')
         userEvent.click(submitButton);
 
         expect(handleAdd).toHaveBeenCalledTimes(1);

--- a/client/src/components/AddClimbedBoulderForm.stories.jsx
+++ b/client/src/components/AddClimbedBoulderForm.stories.jsx
@@ -1,0 +1,18 @@
+import AddClimbedBoulderForm from './AddClimbedBoulderForm';
+
+
+export default {
+  title: 'components/Forms/AddClimbedBoulderForm',
+  component: AddClimbedBoulderForm,
+//   argTypes: { onClick: 'onClick' },
+};
+
+const Template = (args) => (
+
+<AddClimbedBoulderForm {...args} />
+);
+
+export const Default = Template.bind({});
+// Default.args = {
+ 
+// };

--- a/client/src/components/AddClimbedBoulderForm.stories.jsx
+++ b/client/src/components/AddClimbedBoulderForm.stories.jsx
@@ -4,15 +4,10 @@ import AddClimbedBoulderForm from './AddClimbedBoulderForm';
 export default {
   title: 'components/Forms/AddClimbedBoulderForm',
   component: AddClimbedBoulderForm,
-//   argTypes: { onClick: 'onClick' },
 };
 
 const Template = (args) => (
-
 <AddClimbedBoulderForm {...args} />
 );
 
 export const Default = Template.bind({});
-// Default.args = {
- 
-// };

--- a/client/src/components/BoulderCard.jsx
+++ b/client/src/components/BoulderCard.jsx
@@ -7,64 +7,69 @@ import { ReactComponent as SetterIcon } from '../icons/setter.svg';
 import boulderall from '../images/Boulder-all.jpg';
 import boulderstart from '../images/Boulder-start.jpg';
 
-const BoulderCard = ({
-  id,
-  name,
-  sector,
-  level,
-  hold_color,
-  likes,
-  tags,
-  img_start,
-  setter,
-  weighting,
-  detailedMode
-}) => {
+const BoulderCard = ({ boulder, detailedMode }) => {
+  const {
+    id,
+    name,
+    sector,
+    level,
+    hold_color,
+    likes,
+    tags,
+    img_start,
+    setter,
+    weighting,
+  } = boulder;
   const [isInDetailedMode, setIsInDetailedMode] = useState(detailedMode);
 
   return (
     <>
       {isInDetailedMode ? (
         <WrapperLong>
-        <StartPic src={boulderstart} alt='Boulder Start'/>
-        <Name>{name}</Name>
-        <Likes>
-          <Heart style={{ width: '20px' }} />
-          {likes}
-        </Likes>
-        <Level>Level: {level}</Level>
-        <Hold>Hold: {hold_color}</Hold>
-        <SectorIcon>
-          <Map style={{ width: '20px' }} />
-        </SectorIcon>
-        <Sector>{sector}</Sector>
-        <Setter>
-          <SetterIcon style={{ width: '20px' }} /> {setter}
-        </Setter>
-        <Weighting>Weighting: {weighting}</Weighting>
-        <TagList>
-          {tags.map((tag, index) => (
-            <Tag key={index}>{tag}</Tag>
-          ))}
-        </TagList>
-        <AllPic src={boulderall} alt="Boulder Complete"></AllPic>
-      </WrapperLong> 
+          <StartPic src={boulderstart} alt="Boulder Start" />
+          <Name>{name}</Name>
+          <Likes>
+            <Heart style={{ width: '20px' }} />
+            {likes}
+          </Likes>
+          <Level>Level: {level}</Level>
+          <Hold>Hold: {hold_color}</Hold>
+          <SectorIcon>
+            <Map style={{ width: '20px' }} />
+          </SectorIcon>
+          <Sector>{sector}</Sector>
+          <Setter>
+            <SetterIcon style={{ width: '20px' }} /> {setter}
+          </Setter>
+          <Weighting>Weighting: {weighting}</Weighting>
+          <TagList>
+            {tags.map((tag, index) => (
+              <Tag key={index}>{tag}</Tag>
+            ))}
+          </TagList>
+          <AllPic src={boulderall} alt="Boulder Complete"></AllPic>
+        </WrapperLong>
       ) : (
         <WrapperShort>
-        <StartPic src={boulderstart} alt='Boulder Start'/>
-        <Name>{name}</Name>
-        <Likes>
-          <Heart style={{ width: '20px' }} />
-          {likes}
-        </Likes>
-        <Level>Level: {level}</Level>
-        <Hold>Hold: {hold_color}</Hold>
-        <SectorIcon>
-          <Map style={{ width: '20px' }} />
-        </SectorIcon>
-        <Sector>{sector}</Sector>
-       <StyledLink onClick={() => setIsInDetailedMode(true)} to={`/add/${id}`}>Climb</StyledLink>
-      </WrapperShort>
+          <StartPic src={boulderstart} alt="Boulder Start" />
+          <Name>{name}</Name>
+          <Likes>
+            <Heart style={{ width: '20px' }} />
+            {likes}
+          </Likes>
+          <Level>Level: {level}</Level>
+          <Hold>Hold: {hold_color}</Hold>
+          <SectorIcon>
+            <Map style={{ width: '20px' }} />
+          </SectorIcon>
+          <Sector>{sector}</Sector>
+          <StyledLink
+            onClick={() => setIsInDetailedMode(true)}
+            to={`/add/${id}`}
+          >
+            Climb
+          </StyledLink>
+        </WrapperShort>
       )}
     </>
   );
@@ -184,6 +189,3 @@ const AllPic = styled.img`
   grid-column: 5/6;
   grid-row: 1/6;
 `;
-
-
-

--- a/client/src/components/BoulderCard.jsx
+++ b/client/src/components/BoulderCard.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { ReactComponent as Map } from '../icons/map.svg';
 import { ReactComponent as Heart } from '../icons/heart.svg';
 import { ReactComponent as SetterIcon } from '../icons/setter.svg';
@@ -17,8 +18,9 @@ const BoulderCard = ({
   img_start,
   setter,
   weighting,
+  detailedMode
 }) => {
-  const [isInDetailedMode, setIsInDetailedMode] = useState(false);
+  const [isInDetailedMode, setIsInDetailedMode] = useState(detailedMode);
 
   return (
     <>
@@ -63,7 +65,7 @@ const BoulderCard = ({
           <Map style={{ width: '20px' }} />
         </SectorIcon>
         <Sector>{sector}</Sector>
-        <Button onClick={() => setIsInDetailedMode(true)}>Climb</Button>
+       <Link onClick={() => setIsInDetailedMode(true)} to={`/add/${id}`}><Button>Climb</Button></Link>
       </WrapperShort>
       )}
     </>

--- a/client/src/components/BoulderCard.jsx
+++ b/client/src/components/BoulderCard.jsx
@@ -27,7 +27,6 @@ const BoulderCard = ({
       {isInDetailedMode ? (
         <WrapperLong>
         <StartPic src={boulderstart} alt='Boulder Start'/>
-        <ID>#{id}</ID>
         <Name>{name}</Name>
         <Likes>
           <Heart style={{ width: '20px' }} />
@@ -53,7 +52,6 @@ const BoulderCard = ({
       ) : (
         <WrapperShort>
         <StartPic src={boulderstart} alt='Boulder Start'/>
-        <ID>#{id}</ID>
         <Name>{name}</Name>
         <Likes>
           <Heart style={{ width: '20px' }} />
@@ -111,13 +109,9 @@ const StartPic = styled.img`
   grid-column: 1/2;
   grid-row: 1/3;
 `;
-const ID = styled.p`
-  grid-column: 2/3;
-  grid-row: 1/2;
-`;
 
 const Name = styled.h2`
-  grid-column: 3/5;
+  grid-column: 2/5;
   grid-row: 1/2;
   font-size: 1rem;
   text-overflow: ellipsis;

--- a/client/src/components/BoulderCard.jsx
+++ b/client/src/components/BoulderCard.jsx
@@ -65,7 +65,7 @@ const BoulderCard = ({
           <Map style={{ width: '20px' }} />
         </SectorIcon>
         <Sector>{sector}</Sector>
-       <Link onClick={() => setIsInDetailedMode(true)} to={`/add/${id}`}><Button>Climb</Button></Link>
+       <StyledLink onClick={() => setIsInDetailedMode(true)} to={`/add/${id}`}>Climb</StyledLink>
       </WrapperShort>
       )}
     </>
@@ -144,10 +144,18 @@ const Sector = styled.p`
   grid-column: 3/5;
   grid-row: 3/4;
 `;
-const Button = styled.button`
+const StyledLink = styled(Link)`
   font-size: inherit;
+  color: inherit;
   grid-column: 5/6;
   grid-row: 1/4;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-decoration: none;
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  background-color: var(--color-cyan);
 `;
 
 const TagList = styled.ul`

--- a/client/src/components/BoulderCard.jsx
+++ b/client/src/components/BoulderCard.jsx
@@ -104,9 +104,10 @@ const WrapperLong = styled.li`
 `;
 
 const StartPic = styled.img`
-  object-fit: cover;
-  width: 100%;
+  object-fit: contain;
+  max-width: 100%;
   max-height: 100%;
+  border-radius: 100%;
   grid-column: 1/2;
   grid-row: 1/3;
 `;
@@ -183,7 +184,7 @@ const Weighting = styled.p`
 `;
 
 const AllPic = styled.img`
-  object-fit: cover;
+  object-fit: contain;
   width: 100%;
   max-height: 100%;
   grid-column: 5/6;

--- a/client/src/components/BoulderCard.spec.jsx
+++ b/client/src/components/BoulderCard.spec.jsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import BoulderCard from './BoulderCard';
+import { MemoryRouter as Router } from 'react-router-dom';
+
 
 const Boulder = {
   number: 1,
@@ -22,23 +24,24 @@ const Boulder = {
 describe('BoulderCard', () => {
   it('renders the a list item with a title, an img, 5 details and a button and renders four more details after button click', () => {
     render(
+      <Router>
       <BoulderCard
         id={Boulder.number}
         name={Boulder.name}
         sector={Boulder.sector}
         level={Boulder.level}
-        handle_color={Boulder.handle_color}
+        hold_color={Boulder.handle_color}
         likes={Boulder.number_of_likes}
         tags={Boulder.tags}
         setter={Boulder.setter}
         weighting={Boulder.weighting}
       />
+      </Router>
     );
     const cardHeader = screen.getByRole('heading');
     const cardPicture = screen.getByRole('img');
-    const button = screen.getByRole('button');
+    const button = screen.getByRole('link');
 
-    const id = screen.getByText(/#1/);
     const sector = screen.getByText(/Monkey Island/i);
     const level = screen.getByText(/Level: 5/);
     const handle_color = screen.getByText(/black/);
@@ -50,7 +53,6 @@ describe('BoulderCard', () => {
     expect(cardPicture).toBeInTheDocument();
     expect(cardHeader).toHaveTextContent('Black Widow and the people');
     expect(button).toBeInTheDocument();
-    expect(id).toBeInTheDocument();
     expect(sector).toBeInTheDocument();
     expect(level).toBeInTheDocument();
     expect(handle_color).toBeInTheDocument();

--- a/client/src/components/BoulderCard.stories.jsx
+++ b/client/src/components/BoulderCard.stories.jsx
@@ -1,20 +1,18 @@
 import BoulderCard from './BoulderCard';
 import { MemoryRouter as Router } from 'react-router-dom';
 
-
-
 export default {
   title: 'components/Cards/BoulderCard',
   component: BoulderCard,
   argTypes: { onClick: 'onClick' },
 };
 
-const Template = (args) => (
+const Template = args => (
   <Router>
-<ul>
-<BoulderCard {...args} />
-</ul>
-</Router>
+    <ul>
+      <BoulderCard {...args} />
+    </ul>
+  </Router>
 );
 
 export const Default = Template.bind({});

--- a/client/src/components/BoulderCard.stories.jsx
+++ b/client/src/components/BoulderCard.stories.jsx
@@ -1,4 +1,6 @@
 import BoulderCard from './BoulderCard';
+import { MemoryRouter as Router } from 'react-router-dom';
+
 
 
 export default {
@@ -8,9 +10,12 @@ export default {
 };
 
 const Template = (args) => (
+  <Router>
 <ul>
 <BoulderCard {...args} />
-</ul>);
+</ul>
+</Router>
+);
 
 export const Default = Template.bind({});
 Default.args = {

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import GlobalStyles from './GlobalStyles';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
+  <BrowserRouter>
   <React.StrictMode>
     <GlobalStyles/>
     <App />
   </React.StrictMode>
+  </BrowserRouter>
 );

--- a/client/src/pages/Add.jsx
+++ b/client/src/pages/Add.jsx
@@ -1,38 +1,30 @@
 import BoulderCard from '../components/BoulderCard';
-import styled from 'styled-components'
-import { useParams } from 'react-router-dom';
-
+import { useParams, Link } from 'react-router-dom';
 
 const Add = ({bouldersList}) => {
     const { id } = useParams()
+    const currentBoulder = bouldersList.find(boulder => boulder.number === Number(id));
   return (
-    <BoulderList role="list">
-      {bouldersList.map(boulder => (
+    <>
+      <Link to={`/`}>Back to Boulder List</Link>
+      {currentBoulder ? (
         <BoulderCard
-          key={boulder.number}
-          id={boulder.number}
-          name={boulder.name}
-          sector={boulder.sector}
-          level={boulder.level}
-          hold_color={boulder.hold_color}
-          img_start={boulder.img_start}
-          likes={boulder.number_of_likes}
-          setter={boulder.setter}
-          tags={boulder.tags}
-          weighting={boulder.weighting}
+          id={currentBoulder.number}
+          name={currentBoulder.name}
+          sector={currentBoulder.sector}
+          level={currentBoulder.level}
+          hold_color={currentBoulder.hold_color}
+          img_start={currentBoulder.img_start}
+          likes={currentBoulder.number_of_likes}
+          setter={currentBoulder.setter}
+          tags={currentBoulder.tags}
+          weighting={currentBoulder.weighting}
           detailedMode={true}
         />
-      ))}
-    </BoulderList>
+        ) : (''
+        )}
+    </>
   );
 };
-
-
-const BoulderList = styled.ul`
-  width: 95%;
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-`
 
 export default Add;

--- a/client/src/pages/Add.jsx
+++ b/client/src/pages/Add.jsx
@@ -9,6 +9,7 @@ const Add = ({bouldersList}) => {
     const currentBoulder = bouldersList.find(boulder => boulder.number === Number(id));
 
     const [newClimbedBoulder, setNewClimbedBoulder] = useState();
+    console.log(newClimbedBoulder)
 
   const saveClimbedBoulder = (date, projected, attempts, result, liked, levelFeedback) => {
     setNewClimbedBoulder({
@@ -47,7 +48,16 @@ const Add = ({bouldersList}) => {
         <AddClimbedBoulderForm
         saveClimbedBoulder={saveClimbedBoulder}/>
         {newClimbedBoulder && (
+          <>
           <p>You have successfully saved a new entry for this boulder!</p>
+          {/* <p>Boulder ID: {newClimbedBoulder.boulder_id}</p>
+          <p>Climb Date: {newClimbedBoulder.date}</p>
+          <p>Projected: {newClimbedBoulder.projected}</p>
+          <p>Attempts: {newClimbedBoulder.attempts}</p>
+          <p>Result: {newClimbedBoulder.result}</p>
+          <p>Liked: {newClimbedBoulder.liked}</p>
+          <p>Level Feedback: {newClimbedBoulder.level_feedback}</p> */}
+          </>
         )}
         <Link to={`/`}>Back to Boulder List</Link>
     </>

--- a/client/src/pages/Add.jsx
+++ b/client/src/pages/Add.jsx
@@ -1,0 +1,38 @@
+import BoulderCard from '../components/BoulderCard';
+import styled from 'styled-components'
+import { useParams } from 'react-router-dom';
+
+
+const Add = ({bouldersList}) => {
+    const { id } = useParams()
+  return (
+    <BoulderList role="list">
+      {bouldersList.map(boulder => (
+        <BoulderCard
+          key={boulder.number}
+          id={boulder.number}
+          name={boulder.name}
+          sector={boulder.sector}
+          level={boulder.level}
+          hold_color={boulder.hold_color}
+          img_start={boulder.img_start}
+          likes={boulder.number_of_likes}
+          setter={boulder.setter}
+          tags={boulder.tags}
+          weighting={boulder.weighting}
+          detailedMode={true}
+        />
+      ))}
+    </BoulderList>
+  );
+};
+
+
+const BoulderList = styled.ul`
+  width: 95%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+`
+
+export default Add;

--- a/client/src/pages/Add.jsx
+++ b/client/src/pages/Add.jsx
@@ -9,7 +9,6 @@ const Add = ({bouldersList}) => {
     const currentBoulder = bouldersList.find(boulder => boulder.number === Number(id));
 
     const [newClimbedBoulder, setNewClimbedBoulder] = useState();
-    console.log(newClimbedBoulder)
 
   const saveClimbedBoulder = (projected, attempts, result, liked, levelFeedback) => {
     setNewClimbedBoulder({

--- a/client/src/pages/Add.jsx
+++ b/client/src/pages/Add.jsx
@@ -51,10 +51,10 @@ const Add = ({bouldersList}) => {
           <p>You have successfully saved a new entry for this boulder!</p>
           <p>Boulder ID: {newClimbedBoulder.boulder_id}</p>
           <p>Climb Date: {newClimbedBoulder.date.toISOString()}</p>
-          <p>Projected: {newClimbedBoulder.projected}</p>
+          <p>Projected: {newClimbedBoulder.projected ? "true" : "false"}</p>
           <p>Attempts: {newClimbedBoulder.attempts}</p>
           <p>Result: {newClimbedBoulder.result}</p>
-          <p>Liked: {newClimbedBoulder.liked}</p>
+          <p>Liked: {newClimbedBoulder.liked ? "true" : "false"}</p>
           <p>Level Feedback: {newClimbedBoulder.level_feedback}</p>
           </>
         )}

--- a/client/src/pages/Add.jsx
+++ b/client/src/pages/Add.jsx
@@ -11,12 +11,12 @@ const Add = ({bouldersList}) => {
     const [newClimbedBoulder, setNewClimbedBoulder] = useState();
     console.log(newClimbedBoulder)
 
-  const saveClimbedBoulder = (date, projected, attempts, result, liked, levelFeedback) => {
+  const saveClimbedBoulder = (projected, attempts, result, liked, levelFeedback) => {
     setNewClimbedBoulder({
       id: '999999',
       climber_id: '9999999999',
       boulder_id: id,
-      date: date,
+      date: new Date(),
       projected: projected,
       attempts: attempts,
       result: result,
@@ -50,13 +50,13 @@ const Add = ({bouldersList}) => {
         {newClimbedBoulder && (
           <>
           <p>You have successfully saved a new entry for this boulder!</p>
-          {/* <p>Boulder ID: {newClimbedBoulder.boulder_id}</p>
-          <p>Climb Date: {newClimbedBoulder.date}</p>
+          <p>Boulder ID: {newClimbedBoulder.boulder_id}</p>
+          <p>Climb Date: {newClimbedBoulder.date.toISOString()}</p>
           <p>Projected: {newClimbedBoulder.projected}</p>
           <p>Attempts: {newClimbedBoulder.attempts}</p>
           <p>Result: {newClimbedBoulder.result}</p>
           <p>Liked: {newClimbedBoulder.liked}</p>
-          <p>Level Feedback: {newClimbedBoulder.level_feedback}</p> */}
+          <p>Level Feedback: {newClimbedBoulder.level_feedback}</p>
           </>
         )}
         <Link to={`/`}>Back to Boulder List</Link>

--- a/client/src/pages/Add.jsx
+++ b/client/src/pages/Add.jsx
@@ -1,13 +1,32 @@
 import BoulderCard from '../components/BoulderCard';
 import AddClimbedBoulderForm from '../components/AddClimbedBoulderForm';
 import { useParams, Link } from 'react-router-dom';
+import { useState } from 'react';
+import styled from 'styled-components';
 
 const Add = ({bouldersList}) => {
     const { id } = useParams()
     const currentBoulder = bouldersList.find(boulder => boulder.number === Number(id));
-  return (
+
+    const [newClimbedBoulder, setNewClimbedBoulder] = useState();
+
+  const saveClimbedBoulder = (date, projected, attempts, result, liked, levelFeedback) => {
+    setNewClimbedBoulder({
+      id: '999999',
+      climber_id: '9999999999',
+      boulder_id: id,
+      date: date,
+      projected: projected,
+      attempts: attempts,
+      result: result,
+      liked: liked,
+      level_feedback: levelFeedback,
+    });
+  };
+  
+    return (
     <>
-      
+      <BoulderList role="list">
       {currentBoulder ? (
         <BoulderCard
           id={currentBoulder.number}
@@ -24,10 +43,22 @@ const Add = ({bouldersList}) => {
         />
         ) : (''
         )}
-        <AddClimbedBoulderForm/>
-      <Link to={`/`}>Back to Boulder List</Link>
+        </BoulderList>
+        <AddClimbedBoulderForm
+        saveClimbedBoulder={saveClimbedBoulder}/>
+        {newClimbedBoulder && (
+          <p>You have successfully saved a new entry for this boulder!</p>
+        )}
+        <Link to={`/`}>Back to Boulder List</Link>
     </>
   );
 };
+
+const BoulderList = styled.ul`
+  width: 95%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+`
 
 export default Add;

--- a/client/src/pages/Add.jsx
+++ b/client/src/pages/Add.jsx
@@ -1,4 +1,5 @@
 import BoulderCard from '../components/BoulderCard';
+import AddClimbedBoulderForm from '../components/AddClimbedBoulderForm';
 import { useParams, Link } from 'react-router-dom';
 
 const Add = ({bouldersList}) => {
@@ -6,7 +7,7 @@ const Add = ({bouldersList}) => {
     const currentBoulder = bouldersList.find(boulder => boulder.number === Number(id));
   return (
     <>
-      <Link to={`/`}>Back to Boulder List</Link>
+      
       {currentBoulder ? (
         <BoulderCard
           id={currentBoulder.number}
@@ -23,6 +24,8 @@ const Add = ({bouldersList}) => {
         />
         ) : (''
         )}
+        <AddClimbedBoulderForm/>
+      <Link to={`/`}>Back to Boulder List</Link>
     </>
   );
 };

--- a/client/src/pages/Add.jsx
+++ b/client/src/pages/Add.jsx
@@ -5,9 +5,9 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 const Add = ({bouldersList}) => {
+  
     const { id } = useParams()
-    const currentBoulder = bouldersList.find(boulder => boulder.number === Number(id));
-
+    const currentBoulder = bouldersList.find(boulder => boulder.id === id);
     const [newClimbedBoulder, setNewClimbedBoulder] = useState();
 
   const saveClimbedBoulder = (projected, attempts, result, liked, levelFeedback) => {
@@ -29,16 +29,7 @@ const Add = ({bouldersList}) => {
       <BoulderList role="list">
       {currentBoulder ? (
         <BoulderCard
-          id={currentBoulder.number}
-          name={currentBoulder.name}
-          sector={currentBoulder.sector}
-          level={currentBoulder.level}
-          hold_color={currentBoulder.hold_color}
-          img_start={currentBoulder.img_start}
-          likes={currentBoulder.number_of_likes}
-          setter={currentBoulder.setter}
-          tags={currentBoulder.tags}
-          weighting={currentBoulder.weighting}
+         boulder={currentBoulder}
           detailedMode={true}
         />
         ) : (''
@@ -48,7 +39,7 @@ const Add = ({bouldersList}) => {
         saveClimbedBoulder={saveClimbedBoulder}/>
         {newClimbedBoulder && (
           <>
-          <p>You have successfully saved a new entry for this boulder!</p>
+          <h3>You have successfully saved a new entry for this boulder!</h3>
           <p>Boulder ID: {newClimbedBoulder.boulder_id}</p>
           <p>Climb Date: {newClimbedBoulder.date.toISOString()}</p>
           <p>Projected: {newClimbedBoulder.projected ? "true" : "false"}</p>

--- a/client/src/pages/Find.jsx
+++ b/client/src/pages/Find.jsx
@@ -7,17 +7,8 @@ const Find = ({bouldersList}) => {
     <BoulderList role="list">
       {bouldersList.map(boulder => (
         <BoulderCard
-          key={boulder.number}
-          id={boulder.number}
-          name={boulder.name}
-          sector={boulder.sector}
-          level={boulder.level}
-          hold_color={boulder.hold_color}
-          img_start={boulder.img_start}
-          likes={boulder.number_of_likes}
-          setter={boulder.setter}
-          tags={boulder.tags}
-          weighting={boulder.weighting}
+          key={boulder.id}
+          boulder={boulder}
           detailedMode={false}
         />
       ))}

--- a/client/src/pages/Find.jsx
+++ b/client/src/pages/Find.jsx
@@ -1,0 +1,35 @@
+import BoulderCard from '../components/BoulderCard';
+import styled from 'styled-components'
+
+
+const Find = ({bouldersList}) => {
+  return (
+    <BoulderList role="list">
+      {bouldersList.map(boulder => (
+        <BoulderCard
+          key={boulder.number}
+          id={boulder.number}
+          name={boulder.name}
+          sector={boulder.sector}
+          level={boulder.level}
+          hold_color={boulder.hold_color}
+          img_start={boulder.img_start}
+          likes={boulder.number_of_likes}
+          setter={boulder.setter}
+          tags={boulder.tags}
+          weighting={boulder.weighting}
+          detailedMode={false}
+        />
+      ))}
+    </BoulderList>
+  );
+};
+
+export default Find;
+
+const BoulderList = styled.ul`
+  width: 95%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+`


### PR DESCRIPTION
Hi,
with this pull request I have implemented the additional page "Add" where now the detailed card is shown along with a new form that the climber can use to enter the climb result for the selected boulder. 

The list of boulders with the compact card mode is to be found on the  page "Find".

In order to do the above I have implemented react router.

Moreover I have eliminated the ID from the boulder card as I decided that this is not necessary for the climber.

I also decided to take off the date from the climbed boulder form (different from the original user story) and rather set this as a default value with the current date in the background. If I have more time later and can add a feature for the climber so that he can also change the date but this is not necessary for the mvp.

Finally I did not implement the submit button to be disabled initially. The climber will rather save a result with every click on the save button regardless if a change was performed in the form. This will not hurt as the  result will be overwritten each time in the db later.

Thank you for reviewing this pull request.