### PR TITLE
fix climb result and filter for touched, none

### DIFF
--- a/client/src/components/AddClimbedBoulderForm.jsx
+++ b/client/src/components/AddClimbedBoulderForm.jsx
@@ -25,7 +25,7 @@ const AddClimbedBoulderForm = ({
 
   const [newProjected, setNewProjected] = useState('');
   const [newAttempts, setNewAttempts] = useState(0);
-  const [newResult, setNewResult] = useState('None');
+  const [newResult, setNewResult] = useState('Touched');
   const [newLiked, setNewLiked] = useState('');
   const [newLevelFeedback, setNewLevelFeedback] = useState('');
 
@@ -133,7 +133,7 @@ const AddClimbedBoulderForm = ({
             <ResetButton
               type="button"
               onClick={() => {
-                setNewResult('None');
+                setNewResult('Touched');
               }}
             >
               <FaUndoAlt />

--- a/client/src/components/BoulderCard.jsx
+++ b/client/src/components/BoulderCard.jsx
@@ -69,8 +69,8 @@ const BoulderCard = ({ boulder, detailedMode }) => {
             </Likes>
             {climbed !== 'None' ? <Climbed>{climbed}</Climbed> : ''}
             {climbed !== 'Zone' &&
-            climbed !== 'None' &&
-            climbed !== undefined ? (
+            climbed !== 'Touched' &&
+            climbed !== 'None' ? (
               <Checked />
             ) : (
               ''


### PR DESCRIPTION
This pull request includes some restructuring for the handling of "climbed boulder results".
The filter can now also filter on "just touched" boulders and boulders that have no climb result at all.
Also the respective climb result presentation on the boulder card is been taken care of.